### PR TITLE
Ticket 1488: error message more explicit

### DIFF
--- a/db_checker.py
+++ b/db_checker.py
@@ -143,7 +143,7 @@ class TestPVUnits(unittest.TestCase):
                 print "ERROR: Missing description on " + str(rec)
                 err += 1
 
-        self.assertTrue(err == 0, "Missing description on interesting PVs in project")
+        self.assertTrue(err == 0, "Missing or duplicate description on interesting PVs in project")
 
     def test_interest_syntax(self):
         """


### PR DESCRIPTION
As the script checks that interest records have exactly one description, I've changed the error message to be more explicit.

This is for ISISComputingGroup/IBEX#1488
