### PR TITLE
Permit cdeg and cdeg/ss as special cases for GemORC

### DIFF
--- a/db_checker.py
+++ b/db_checker.py
@@ -29,7 +29,13 @@ allowed_prefixable_units = {'A', 'angstrom', 'bar', 'bit', 'byte', 'C', 'count',
                             'Hz', 'inch', 'interrupt', 'K', 'L', 'm', 'min', 'minute', 'ohm', 'Oersted', '%',
                             'photon', 'pixel', 'radian', 's', 'torr', 'step', 'T', 'V', 'Pa', 'deg', 'stp', 'W'}
 allowed_unit_prefixes = {'T', 'G', 'M', 'k', 'm', 'u', 'n', 'p', 'f'}
-allowed_non_prefixable_units = {'cm'}
+allowed_non_prefixable_units = {
+    'cm',
+    'cdeg'
+}
+allowed_standalone_units = {
+    'cdeg/ss',  # Needed by the GORC. Latter is a special case because cdeg/s^2 too long}
+}
 
 dbs = list()
 
@@ -152,6 +158,9 @@ class TestPVUnits(unittest.TestCase):
         """
         This method checks that the given unit conforms to standard
         """
+        if raw_unit in allowed_standalone_units:
+            return True
+
         # expand macro $(A) to a valid unit, expand $(A=B) to B
         processed_unit = re.sub(r'\$[({].*?=(.*)?[})]', r'\1', raw_unit)
         processed_unit = re.sub(r'\$[({].*?[})]', 'm', processed_unit)

--- a/test/test_units.db
+++ b/test/test_units.db
@@ -121,3 +121,15 @@ record(ao, "SHOULDFAIL:BADUNIT:negative_power")
 	field(DESC, "prefer 1/m")
 	field(EGU, "m^-1")
 }
+
+record(ao, "SHOULDPASS:CDEG")
+{
+	field(DESC, "Used by GEMORC")
+	field(EGU, "cdeg")
+}
+
+record(ao, "SHOULDPASS:CDEG_OVER_SS")
+{
+	field(DESC, "Used by GEMORC because cdeg/s^2 too long")
+	field(EGU, "cdeg/ss")
+}


### PR DESCRIPTION
## Description

I've added a couple of units, notably `cdeg` and `cdeg/ss` that are needed by the GEM Oscillating Radial Collimator. The latter is needed because of the 7-char limit on units that prevents use of `cdeg/s^2`

## Ticket

https://github.com/ISISComputingGroup/IBEX/issues/2409