### PR TITLE
Ticket 4173 : fix multiple fields found in comments

### DIFF
--- a/db_checker.py
+++ b/db_checker.py
@@ -81,7 +81,7 @@ class TestPVUnits(unittest.TestCase):
 
     @ignore(["superlogics.db", "lakeshore336.db", "motor.db"], "Historical failures have not been addressed")
     @ignore(["EPICS_V4"], "Vendor-supplied DBs")
-    @ignore(["DbUnitChecker"], "DB unit checker contains tests that deliberately fail, used as integration tests")
+    #@ignore(["DbUnitChecker"], "DB unit checker contains tests that deliberately fail, used as integration tests")
     def test_multiple_pvs_warning(self):
         """
         This method warns if there are multiple PVs with the same name in the project
@@ -105,7 +105,7 @@ class TestPVUnits(unittest.TestCase):
     @ignore(["separator_current.db"], "Mutually exclusive guards prevent this from ever happening")
     @ignore(["isActiveEurothrm.db"], "Mutually exclusive macro guards prevent this from ever happening")
     @ignore(["optics", "danfysikMps8000"], "Vendor-supplied DBs")
-    @ignore(["DbUnitChecker"], "DB unit checker contains tests that deliberately fail, used as integration tests")
+    #@ignore(["DbUnitChecker"], "DB unit checker contains tests that deliberately fail, used as integration tests")
     @ignore(["ips.db"], "The word 'field' used repeatedly in the DB to refer to a magnetic field confuses the parser, which tries to interpret them as epics field declarations.")
     @ignore(["Mezflipr_common.db"], "Complex macro guards cannot be understood by DbUnitChecker.")
     def test_multiple_properties_on_pvs(self):
@@ -123,7 +123,7 @@ class TestPVUnits(unittest.TestCase):
         self.assertEqual(len(failures), 0, msg=build_failure_message(
             "Multiple fields on PVs in {}".format(self.db.directory), failures))
 
-    @ignore(["DbUnitChecker"], "DB unit checker contains tests that deliberately fail, used as integration tests")
+    #@ignore(["DbUnitChecker"], "DB unit checker contains tests that deliberately fail, used as integration tests")
     def test_interest_units(self):
         """
         This method checks that interesting PVs have units
@@ -140,7 +140,7 @@ class TestPVUnits(unittest.TestCase):
         self.assertEqual(len(failures), 0, msg=build_failure_message(
             "Interesting PVs with no units in {}".format(self.db.directory), failures))
 
-    @ignore(["DbUnitChecker"], "DB unit checker contains tests that deliberately fail, used as integration tests")
+    #@ignore(["DbUnitChecker"], "DB unit checker contains tests that deliberately fail, used as integration tests")
     def test_interest_calc_readonly(self):
         """
         This method checks that interesting PVs that are calc fields are set to
@@ -158,7 +158,7 @@ class TestPVUnits(unittest.TestCase):
         self.assertEqual(len(failures), 0, msg=build_failure_message(
             "Writable calc records in {}".format(self.db.directory), failures))
 
-    @ignore(["DbUnitChecker"], "DB unit checker contains tests that deliberately fail, used as integration tests")
+    #@ignore(["DbUnitChecker"], "DB unit checker contains tests that deliberately fail, used as integration tests")
     def test_desc_length(self):
         """
         This method checks that the description length on all PVs is no longer than 40 chars
@@ -210,7 +210,7 @@ class TestPVUnits(unittest.TestCase):
         return all(is_standalone_unit(u) or is_prefixed_unit(u) for u in units)
 
     @ignore(["optics", "CALab", "DbUnitChecker", "danfysikMps8000", "EPICS_V4", "EdwardsNextTurbo"], "Vendor-supplied DBs")
-    @ignore(["DbUnitChecker"], "DB unit checker contains tests that deliberately fail, used as integration tests")
+    #@ignore(["DbUnitChecker"], "DB unit checker contains tests that deliberately fail, used as integration tests")
     @ignore(["ether_ip"], "Vendor-supplied DBs")
     def test_units_valid(self):
         """
@@ -227,7 +227,7 @@ class TestPVUnits(unittest.TestCase):
         self.assertEqual(len(failures), 0, msg=build_failure_message(
             "Invalid units in {}".format(self.db.directory), failures))
 
-    @ignore(["DbUnitChecker"], "DB unit checker contains tests that deliberately fail, used as integration tests")
+    #@ignore(["DbUnitChecker"], "DB unit checker contains tests that deliberately fail, used as integration tests")
     def test_interest_descriptions(self):
         """
         This method checks all records marked as interesting for description fields
@@ -242,7 +242,7 @@ class TestPVUnits(unittest.TestCase):
             "Missing description in {}".format(self.db.directory), failures))
 
     @ignore(["HVCAENx527ch.db"], "These are externally provided DBs")
-    @ignore(["DbUnitChecker"], "DB unit checker contains tests that deliberately fail, used as integration tests")
+    #@ignore(["DbUnitChecker"], "DB unit checker contains tests that deliberately fail, used as integration tests")
     def test_interest_syntax(self):
         """
         This method tests that all interesting PVs that are not in the names exception list are capitalised and
@@ -263,7 +263,7 @@ class TestPVUnits(unittest.TestCase):
         self.assertEqual(len(failures), 0, msg=build_failure_message(
             "PV syntax incorrect in {}".format(self.db.directory), failures))
 
-    @ignore(["DbUnitChecker"], "DB unit checker contains tests that deliberately fail, used as integration tests")
+    #@ignore(["DbUnitChecker"], "DB unit checker contains tests that deliberately fail, used as integration tests")
     def test_log_info_tags(self):
         """
         This method checks logging records to check that logging tags are not repeated and that the period is not

--- a/db_checker.py
+++ b/db_checker.py
@@ -81,7 +81,7 @@ class TestPVUnits(unittest.TestCase):
 
     @ignore(["superlogics.db", "lakeshore336.db", "motor.db"], "Historical failures have not been addressed")
     @ignore(["EPICS_V4"], "Vendor-supplied DBs")
-    #@ignore(["DbUnitChecker"], "DB unit checker contains tests that deliberately fail, used as integration tests")
+    @ignore(["DbUnitChecker"], "DB unit checker contains tests that deliberately fail, used as integration tests")
     def test_multiple_pvs_warning(self):
         """
         This method warns if there are multiple PVs with the same name in the project
@@ -105,8 +105,7 @@ class TestPVUnits(unittest.TestCase):
     @ignore(["separator_current.db"], "Mutually exclusive guards prevent this from ever happening")
     @ignore(["isActiveEurothrm.db"], "Mutually exclusive macro guards prevent this from ever happening")
     @ignore(["optics", "danfysikMps8000"], "Vendor-supplied DBs")
-    #@ignore(["DbUnitChecker"], "DB unit checker contains tests that deliberately fail, used as integration tests")
-    @ignore(["ips.db"], "The word 'field' used repeatedly in the DB to refer to a magnetic field confuses the parser, which tries to interpret them as epics field declarations.")
+    @ignore(["DbUnitChecker"], "DB unit checker contains tests that deliberately fail, used as integration tests")
     @ignore(["Mezflipr_common.db"], "Complex macro guards cannot be understood by DbUnitChecker.")
     def test_multiple_properties_on_pvs(self):
         """
@@ -123,7 +122,7 @@ class TestPVUnits(unittest.TestCase):
         self.assertEqual(len(failures), 0, msg=build_failure_message(
             "Multiple fields on PVs in {}".format(self.db.directory), failures))
 
-    #@ignore(["DbUnitChecker"], "DB unit checker contains tests that deliberately fail, used as integration tests")
+    @ignore(["DbUnitChecker"], "DB unit checker contains tests that deliberately fail, used as integration tests")
     def test_interest_units(self):
         """
         This method checks that interesting PVs have units
@@ -140,7 +139,7 @@ class TestPVUnits(unittest.TestCase):
         self.assertEqual(len(failures), 0, msg=build_failure_message(
             "Interesting PVs with no units in {}".format(self.db.directory), failures))
 
-    #@ignore(["DbUnitChecker"], "DB unit checker contains tests that deliberately fail, used as integration tests")
+    @ignore(["DbUnitChecker"], "DB unit checker contains tests that deliberately fail, used as integration tests")
     def test_interest_calc_readonly(self):
         """
         This method checks that interesting PVs that are calc fields are set to
@@ -158,7 +157,7 @@ class TestPVUnits(unittest.TestCase):
         self.assertEqual(len(failures), 0, msg=build_failure_message(
             "Writable calc records in {}".format(self.db.directory), failures))
 
-    #@ignore(["DbUnitChecker"], "DB unit checker contains tests that deliberately fail, used as integration tests")
+    @ignore(["DbUnitChecker"], "DB unit checker contains tests that deliberately fail, used as integration tests")
     def test_desc_length(self):
         """
         This method checks that the description length on all PVs is no longer than 40 chars
@@ -210,7 +209,7 @@ class TestPVUnits(unittest.TestCase):
         return all(is_standalone_unit(u) or is_prefixed_unit(u) for u in units)
 
     @ignore(["optics", "CALab", "DbUnitChecker", "danfysikMps8000", "EPICS_V4", "EdwardsNextTurbo"], "Vendor-supplied DBs")
-    #@ignore(["DbUnitChecker"], "DB unit checker contains tests that deliberately fail, used as integration tests")
+    @ignore(["DbUnitChecker"], "DB unit checker contains tests that deliberately fail, used as integration tests")
     @ignore(["ether_ip"], "Vendor-supplied DBs")
     def test_units_valid(self):
         """
@@ -227,7 +226,7 @@ class TestPVUnits(unittest.TestCase):
         self.assertEqual(len(failures), 0, msg=build_failure_message(
             "Invalid units in {}".format(self.db.directory), failures))
 
-    #@ignore(["DbUnitChecker"], "DB unit checker contains tests that deliberately fail, used as integration tests")
+    @ignore(["DbUnitChecker"], "DB unit checker contains tests that deliberately fail, used as integration tests")
     def test_interest_descriptions(self):
         """
         This method checks all records marked as interesting for description fields
@@ -242,7 +241,7 @@ class TestPVUnits(unittest.TestCase):
             "Missing description in {}".format(self.db.directory), failures))
 
     @ignore(["HVCAENx527ch.db"], "These are externally provided DBs")
-    #@ignore(["DbUnitChecker"], "DB unit checker contains tests that deliberately fail, used as integration tests")
+    @ignore(["DbUnitChecker"], "DB unit checker contains tests that deliberately fail, used as integration tests")
     def test_interest_syntax(self):
         """
         This method tests that all interesting PVs that are not in the names exception list are capitalised and
@@ -263,7 +262,7 @@ class TestPVUnits(unittest.TestCase):
         self.assertEqual(len(failures), 0, msg=build_failure_message(
             "PV syntax incorrect in {}".format(self.db.directory), failures))
 
-    #@ignore(["DbUnitChecker"], "DB unit checker contains tests that deliberately fail, used as integration tests")
+    @ignore(["DbUnitChecker"], "DB unit checker contains tests that deliberately fail, used as integration tests")
     def test_log_info_tags(self):
         """
         This method checks logging records to check that logging tags are not repeated and that the period is not

--- a/db_parser.py
+++ b/db_parser.py
@@ -42,12 +42,31 @@ def _get_props(keyword, text):
 
     return fields
 
-def is_comment(line):
-    if  (line.find('#') != -1):
-        temp = line.split('#')[1]
-        if (temp.find('"') == -1):
-            print(temp)
+def remove_comments(line):
+    """ Removes comments from a given db line
+    @param line : Single line Db entry 
+    @returns text : parsed string with comments removed, line return added.
 
+    This method finds all single line comments starting with
+    a #. It checks to see whether the # is contained within a string
+    in which case it retains the text proceeds. All other comments are
+    removed before returning the parsed string.
+    """
+    text = ""
+    first_hash = line.find('#')
+    if (first_hash != -1):
+        comment = line.split('#')[1]     
+        real_text = line.split('#')[0]
+        first_quotes = comment.find('"')
+        if (first_quotes == -1) or (first_hash < first_quotes):
+            # if the # is not part of a string or the hash comes before the first quotes
+            text += real_text + '\n'
+        else:
+            text += real_text + comment + '\n'
+    else:
+        text += line + '\n'
+    return text
+    
 def parse_db(db_file):
         """
         This method will parse the text found in the EPICS db files to form groups of Record
@@ -55,24 +74,11 @@ def parse_db(db_file):
         """
 
         text = ""
-        test_text = ""
         temp_text = db_file.get_text()
 
         # remove comments but keep any # that appear in strings (may be able to do better in regex?)
         for line in iter(temp_text.splitlines()):
-            if  (line.find('#') != -1):
-                comment = line.split('#')[1]
-                real_text = line.split('#')[0]
-                if (comment.find('"') == -1): # if not inside a string.
-                    text += real_text + '\n'
-            else:
-                text += line + '\n'
-
-            """
-            if  not (line.find('#') != -1 and (line.find('#') < line.find('"') or line.find('"') == -1)):
-                # is not a comment so add to be parsed
-                text += line + '\n'
-            """
+            text += remove_comments(line)
         recs = []
 
         # cut out the text before the first record

--- a/db_parser.py
+++ b/db_parser.py
@@ -62,7 +62,7 @@ def remove_comments(line):
             # if the # is not part of a string or the hash comes before the first quotes
             text += real_text + '\n'
         else:
-            text += real_text + comment + '\n'
+            text += real_text + '#' +  comment + '\n' #put the # back in, we want it retained.
     else:
         text += line + '\n'
     return text

--- a/db_parser.py
+++ b/db_parser.py
@@ -42,6 +42,11 @@ def _get_props(keyword, text):
 
     return fields
 
+def is_comment(line):
+    if  (line.find('#') != -1):
+        temp = line.split('#')[1]
+        if (temp.find('"') == -1):
+            print(temp)
 
 def parse_db(db_file):
         """
@@ -50,14 +55,24 @@ def parse_db(db_file):
         """
 
         text = ""
+        test_text = ""
         temp_text = db_file.get_text()
 
         # remove comments but keep any # that appear in strings (may be able to do better in regex?)
         for line in iter(temp_text.splitlines()):
-            if not (line.find('#') != -1 and (line.find('#') < line.find('"') or line.find('"') == -1)):
-                # is not a comment so add to be parsed
+            if  (line.find('#') != -1):
+                comment = line.split('#')[1]
+                real_text = line.split('#')[0]
+                if (comment.find('"') == -1): # if not inside a string.
+                    text += real_text + '\n'
+            else:
                 text += line + '\n'
 
+            """
+            if  not (line.find('#') != -1 and (line.find('#') < line.find('"') or line.find('"') == -1)):
+                # is not a comment so add to be parsed
+                text += line + '\n'
+            """
         recs = []
 
         # cut out the text before the first record

--- a/test/test_all.db
+++ b/test/test_all.db
@@ -142,3 +142,12 @@ record(stringin, "SHOULDPASS:BLANK:PINI")
 record(ao, "SHOULDPASS:MULTIPLEWARNING")
 {}
 
+record(calc, "SHOULDPASS:MULTIPLEFIELDS") {
+    field(CALC, "(C=0||C=2)?A:B")  # If heater is present and switched off, display persistent field, else display PSU field
+    field(ASG, "READONLY")
+}
+
+record(calc, "SHOULDPASS:HASHINSTRING") {
+    field(CALC, "(C=0||C=2)?A:#B") 
+    field(ASG, "READONLY")
+}

--- a/test/test_all.db
+++ b/test/test_all.db
@@ -148,6 +148,17 @@ record(calc, "SHOULDPASS:MULTIPLEFIELDS") {
 }
 
 record(calc, "SHOULDPASS:HASHINSTRING") {
-    field(CALC, "(C=0||C=2)?A:#B") 
+    field(CALC, "(C=0||C=2)?A:#C") 
+    field(ASG, "READONLY")
+}
+
+record(calc, "SHOULDPASS:HASHINSTRINGANDCOMMENT") {
+    field(CALC, "(C=0||C=2)?A:#D") #This is a comment with field in it
+    field(ASG, "READONLY")
+}
+
+
+record(calc, "SHOULDPASS:COMMENTEDOUTFIELDSS") {
+    #This is a comment with field in it field(CALC, "(C=0||C=2)?A:#D") 
     field(ASG, "READONLY")
 }


### PR DESCRIPTION
See https://github.com/ISISComputingGroup/IBEX/issues/4173 

Added a new parsing function `remove_comments` to remove comments from Db records. This function retains hashtags within strings. This new function removes the issues found where comments that include the word 'field' cause the tests to fail due to 'multiple field' instances. This also now fixes the need to have an @ignore for the IPS.db file which contains comments with the word field in.

New tests added in test_all.db to test for multiple edge cases involving comments and hashtags.