### PR TITLE
Add exception for tests

### DIFF
--- a/tests/pv_unit_tests.py
+++ b/tests/pv_unit_tests.py
@@ -45,6 +45,8 @@ class TestPVUnits(unittest.TestCase):
         "tpgx6x.template",
         "tpg36x.db",
         "tpg26x.db",
+        "zfmagfld_axes.template",
+        "zfmagfld_axes.db"
     ], "Mutually exclusive guards prevent this from ever happening")
     @ignore(["optics", "danfysikMps8000"], "Vendor-supplied DBs")
     @ignore(["Mezflipr_common.db"], "Complex macro guards cannot be understood by DbUnitChecker.")


### PR DESCRIPTION
Adds exceptions for zero field db files. These are required because writing DAQ recsim tests needs mutually exclusive guards.

Ticket:
https://github.com/ISISComputingGroup/IBEX/issues/4838