### PR TITLE
Ignore win32-x86 and .ci

### DIFF
--- a/utils/loader.py
+++ b/utils/loader.py
@@ -7,10 +7,12 @@ DIRECTORIES_TO_ALWAYS_IGNORE = [
     ".git",
     "O.Common",
     "O.windows-x64",
+    "O.win32-x86",
     "bin",
     "lib",
     "include",
     ".project",
+    ".ci",
     "areaDetector",  # Has some huge DBs which take forever to parse.
 ]
 


### PR DESCRIPTION
Ignore .ci and win32-x86 to fix units failure in builds