### PR TITLE
Ticket4878 convert dbunitchecker python3

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -32,7 +32,8 @@ def run_own_unit_tests(xml_dir):
 
     print("Running self-tests...")
     suite = unittest.TestLoader().discover(os.path.join("utils", "tests"))
-    return xmlrunner.XMLTestRunner(output=str(xml_dir), stream=sys.stdout).run(suite).wasSuccessful()
+    return xmlrunner.XMLTestRunner(output=str(xml_dir), stream=sys.stdout)\
+        .run(suite).wasSuccessful()
 
 
 def run_system_tests(xml_dir, input_dir):
@@ -49,13 +50,16 @@ def run_system_tests(xml_dir, input_dir):
 
     print("Scanning files...")
     for db in set_up(input_dir):
-        suite.addTests([TestPVUnits(test, db) for test in loader.getTestCaseNames(TestPVUnits)])
+        suite.addTests([TestPVUnits(test, db) for test in
+                        loader.getTestCaseNames(TestPVUnits)])
 
     print("Beginning PV unit tests...")
 
     success = xmlrunner.XMLTestRunner(output=xml_dir).run(suite).wasSuccessful()
 
-    print("PV unit tests complete (Took {:.3f} sec)".format(time.time() - start))
+    print(
+        "PV unit tests complete (Took {:.3f} sec)".format(time.time() - start)
+    )
 
     return success
 
@@ -75,20 +79,27 @@ def run_all_tests(xml_dir, input_dir):
 
 def main():
 
-    default_dirs = [os.path.join('..', '..', '..', 'ioc'),
-                    os.path.join('..', '..', '..', 'support'), os.path.join('..', '..')]
+    default_dirs = [
+        os.path.join('..', '..', '..', 'ioc'),
+        os.path.join('..', '..', '..', 'support'),
+        os.path.join('..', '..')
+    ]
 
     # Get output directory from command line arguments
     parser = argparse.ArgumentParser()
-    parser.add_argument('-o', '--output_dir', nargs=1, type=str, default=DEFAULT_DIRECTORY,
-                        help='The directory to save the test reports')
-    parser.add_argument('-i', '--input_dir', nargs='+', type=str, default=default_dirs,
-                        help='The input directories to look for db files within')
+    parser.add_argument(
+        '-o', '--output_dir', nargs=1, type=str, default=DEFAULT_DIRECTORY,
+        help='The directory to save the test reports')
+    parser.add_argument(
+        '-i', '--input_dir', nargs='+', type=str, default=default_dirs,
+        help='The input directories to look for db files within'
+    )
     args = parser.parse_args()
 
     xml_dir = args.output_dir[0]
     success = run_all_tests(xml_dir, args.input_dir)
     sys.exit(0 if success else 1)
+
 
 if __name__ == '__main__':
     main()

--- a/test_checker.bat
+++ b/test_checker.bat
@@ -1,1 +1,1 @@
-%python% run_tests.py -o ./tests -i ./tests
+%python3% run_tests.py -o ./tests -i ./tests

--- a/tests/pv_unit_tests.py
+++ b/tests/pv_unit_tests.py
@@ -24,17 +24,31 @@ class TestPVUnits(unittest.TestCase):
         super(TestPVUnits, self).__init__(methodName=methodName)
         self.db = db
 
-    @ignore(["superlogics.db", "lakeshore336.db", "motor.db"], "Historical failures have not been addressed")
+    @ignore(
+        ["superlogics.db", "lakeshore336.db", "motor.db"],
+        "Historical failures have not been addressed"
+    )
     @ignore(["EPICS_V4"], "Vendor-supplied DBs")
-    @ignore(["DbUnitChecker"], "Contains integration tests which deliberately fail")
-    @ignore(["channel_access_test.template"], "Too complicated for DbUnitChecker to understand")
+    @ignore(
+        ["DbUnitChecker"], "Contains integration tests which deliberately fail"
+    )
+    @ignore(
+        ["channel_access_test.template"],
+        "Too complicated for DbUnitChecker to understand"
+    )
     def test_multiple_pvs_warning(self):
         """
-        This method warns if there are multiple PVs with the same name in the project
+        This method warns if there are multiple PVs with the same name
+        in the project
         """
         failures = db_checks.get_multiple_instances(self.db)
-        self.assertEqual(len(failures), 0, msg=db_checks.build_failure_message(
-            "Multiple fields on PVs in {}".format(self.db.directory), failures))
+        self.assertEqual(
+            len(failures), 0,
+            msg=db_checks.build_failure_message(
+                "Multiple fields on PVs in {}".format(self.db.directory),
+                failures
+            )
+        )
 
     @ignore([
         "moxa1210_aliases.db",
@@ -51,9 +65,17 @@ class TestPVUnits(unittest.TestCase):
         "zfmagfld_axes.db",
     ], "Mutually exclusive guards prevent this from ever happening")
     @ignore(["optics", "danfysikMps8000"], "Vendor-supplied DBs")
-    @ignore(["Mezflipr_common.db"], "Complex macro guards cannot be understood by DbUnitChecker.")
-    @ignore(["axisUtil.db", "motorUtil.db"], "Complex macro guards cannot be understood by DbUnitChecker.")
-    @ignore(["DbUnitChecker"], "Contains integration tests which deliberately fail")
+    @ignore(
+        ["Mezflipr_common.db"],
+        "Complex macro guards cannot be understood by DbUnitChecker."
+    )
+    @ignore(
+        ["axisUtil.db", "motorUtil.db"],
+        "Complex macro guards cannot be understood by DbUnitChecker."
+    )
+    @ignore(
+        ["DbUnitChecker"], "Contains integration tests which deliberately fail"
+    )
     def test_multiple_properties_on_pvs(self):
         """
         This method checks that interesting PVs have units
@@ -62,17 +84,28 @@ class TestPVUnits(unittest.TestCase):
         self.assertEqual(len(failures), 0, msg=db_checks.build_failure_message(
             "Multiple fields on PVs in {}".format(self.db.directory), failures))
 
-    @ignore(["DbUnitChecker"], "Contains integration tests which deliberately fail")
+    @ignore(
+        ["DbUnitChecker"], "Contains integration tests which deliberately fail"
+    )
     def test_interest_units(self):
         """
         This method checks that interesting PVs have units
         """
         failures = db_checks.get_interest_units(self.db)
-        self.assertEqual(len(failures), 0, msg=db_checks.build_failure_message(
-            "Interesting PVs with no units in {}".format(self.db.directory), failures))
+        self.assertEqual(
+            len(failures), 0,
+            msg=db_checks.build_failure_message(
+                "Interesting PVs with no units in {}".format(self.db.directory),
+                failures
+            )
+        )
 
-    @ignore(["DbUnitChecker"], "Contains integration tests which deliberately fail")
-    @ignore(["jsco4180.db"], "Complex calc record sequences not understood properly")
+    @ignore(
+        ["DbUnitChecker"], "Contains integration tests which deliberately fail"
+    )
+    @ignore(
+        ["jsco4180.db"], "Complex calc record sequences not understood properly"
+    )
     def test_interest_calc_readonly(self):
         """
         This method checks that interesting PVs that are calc fields are set to
@@ -82,52 +115,68 @@ class TestPVUnits(unittest.TestCase):
         self.assertEqual(len(failures), 0, msg=db_checks.build_failure_message(
             "Writable calc records in {}".format(self.db.directory), failures))
 
-    @ignore(["DbUnitChecker"], "Contains integration tests which deliberately fail")
+    @ignore(
+        ["DbUnitChecker"], "Contains integration tests which deliberately fail"
+    )
     def test_desc_length(self):
         """
-        This method checks that the description length on all PVs is no longer than 40 chars
+        This method checks that the description length on all PVs is no longer
+        than 40 chars
         """
         failures = db_checks.get_desc_length(self.db)
         self.assertEqual(len(failures), 0, msg=db_checks.build_failure_message(
             "Description too long in {}".format(self.db.directory), failures))
 
-    @ignore(["optics", "CALab", "danfysikMps8000", "EPICS_V4", "EdwardsNextTurbo"], "Vendor-supplied DBs")
+    @ignore(
+        ["optics", "CALab", "danfysikMps8000", "EPICS_V4", "EdwardsNextTurbo"],
+        "Vendor-supplied DBs"
+    )
     @ignore(["ether_ip", "seq"], "Vendor-supplied DBs")
     @ignore(["qepro.template"], "Historical failures not addressed")
-    @ignore(["DbUnitChecker"], "Contains integration tests which deliberately fail")
+    @ignore(
+        ["DbUnitChecker"], "Contains integration tests which deliberately fail"
+    )
     def test_units_valid(self):
         """
-        This method loops through all found records and finds the unique units. It then checks these units are standard
+        This method loops through all found records and finds the unique units.
+        It then checks these units are standard
         """
         failures = db_checks.get_units_valid(self.db)     
         self.assertEqual(len(failures), 0, msg=db_checks.build_failure_message(
             "Invalid units in {}".format(self.db.directory), failures))
 
-    @ignore(["DbUnitChecker"], "Contains integration tests which deliberately fail")
+    @ignore(
+        ["DbUnitChecker"], "Contains integration tests which deliberately fail"
+    )
     def test_interest_descriptions(self):
         """
-        This method checks all records marked as interesting for description fields
+        This method checks all records marked as interesting for
+        description fields
         """
         failures = db_checks.get_interest_descriptions(self.db)
         self.assertEqual(len(failures), 0, msg=db_checks.build_failure_message(
             "Missing description in {}".format(self.db.directory), failures))
 
-    @ignore(["DbUnitChecker"], "Contains integration tests which deliberately fail")
+    @ignore(
+        ["DbUnitChecker"], "Contains integration tests which deliberately fail"
+    )
     @ignore(["HVCAENx527ch.db"], "These are externally provided DBs")
     def test_interest_syntax(self):
         """
-        This method tests that all interesting PVs that are not in the names exception list are capitalised and
-        contain only A-Z 0-9 _ :
+        This method tests that all interesting PVs that are not in the names
+        exception list are capitalised and contain only A-Z 0-9 _ :
         """
         failures = db_checks.get_interest_syntax(self.db)
         self.assertEqual(len(failures), 0, msg=db_checks.build_failure_message(
              "PV syntax incorrect in {}".format(self.db.directory), failures))
 
-    @ignore(["DbUnitChecker"], "Contains integration tests which deliberately fail")
+    @ignore(
+        ["DbUnitChecker"], "Contains integration tests which deliberately fail"
+    )
     def test_log_info_tags(self):
         """
-        This method checks logging records to check that logging tags are not repeated and that the period is not
-        defined in two ways.
+        This method checks logging records to check that logging tags are
+        not repeated and that the period is not defined in two ways.
         """
         failures = db_checks.get_log_info_tags(self.db)
         self.assertEqual(len(failures), 0, msg=db_checks.build_failure_message(

--- a/utils/EPICS_collections.py
+++ b/utils/EPICS_collections.py
@@ -64,7 +64,8 @@ class Record:
 
     def has_field(self, search):
         """
-        This method checks all contained fields for instances of a pv given by the search input
+        This method checks all contained fields for instances of a
+        pv given by the search input
         """
         for field in self.fields:
             if field.name == search:
@@ -73,7 +74,8 @@ class Record:
 
     def get_field(self, search):
         """
-        This method returns the values of the first field contained within the record that matches the search input
+        This method returns the values of the first field contained within
+        the record that matches the search input
         If no field exists None is returned
         """
         for field in self.fields:
@@ -89,7 +91,8 @@ class Record:
 
     def get_info(self, search):
         """
-        This method returns a list of the values of all contained info fields that match the search input
+        This method returns a list of the values of all contained info
+        fields that match the search input
         """
         found_values = []
         for info in self.infos:
@@ -109,7 +112,8 @@ class Record:
 
 class Field:
     """
-    This class holds all the data about each field within a record, not using a dictionary as may not be unique
+    This class holds all the data about each field within a record,
+    not using a dictionary as may not be unique
     """
     def __init__(self, name, value):
         self.name = name.strip()

--- a/utils/db_parser.py
+++ b/utils/db_parser.py
@@ -4,8 +4,8 @@ from EPICS_collections import Db, Record, Field
 
 def _check_string(text):
     """
-    Helper function to return the data between the next comma and closed bracket, even if it's a string containing
-    commas/brackets
+    Helper function to return the data between the next comma and closed
+    bracket, even if it's a string containing commas/brackets
     """
     quote_pos = text.find('"')
     if quote_pos < text.find(')') and quote_pos != -1:
@@ -22,8 +22,9 @@ def _check_string(text):
 
 def _get_props(keyword, text):
     """
-    This method searches for valid EPICS formatted data under the given keyword in the text, specifically
-    avoiding strings containing that keyword. E.g. info and field
+    This method searches for valid EPICS formatted data under the given
+    keyword in the text, specifically avoiding strings containing
+    that keyword. E.g. info and field
     A list of this data is returned.
     """
     fields = []
@@ -69,14 +70,15 @@ def remove_comments(line):
 
 def parse_db(db_file):
     """
-    This method will parse the text found in the EPICS db files to form groups of Record
-    and Field instances.
+    This method will parse the text found in the EPICS db files to form groups
+    of Record and Field instances.
     """
 
     text = ""
     temp_text = db_file.get_text()
 
-    # remove comments but keep any # that appear in strings (may be able to do better in regex?)
+    # remove comments but keep any # that appear in strings
+    # (may be able to do better in regex?)
     for line in iter(temp_text.splitlines()):
         text += remove_comments(line)
 
@@ -111,7 +113,8 @@ def parse_db(db_file):
         # check if the next instance of record occurs in a string
 
         if re.search('"[^"]*record[^"]*?"', braced_text):
-            rec_pos = re.search('"[^"]*record[^"]*?"', text).end()  # find where record is used in a string
+            # find where record is used in a string
+            rec_pos = re.search('"[^"]*record[^"]*?"', text).end()
             text = text[rec_pos+5:]
 
         rec_pos = text.find("record")

--- a/utils/db_parser.py
+++ b/utils/db_parser.py
@@ -1,5 +1,5 @@
 import re
-from EPICS_collections import Db, Record, Field
+from .EPICS_collections import Db, Record, Field
 
 
 def _check_string(text):

--- a/utils/loader.py
+++ b/utils/loader.py
@@ -1,5 +1,5 @@
 from os.path import join
-from db_parser import parse_db
+from .db_parser import parse_db
 import os
 
 

--- a/utils/loader.py
+++ b/utils/loader.py
@@ -35,7 +35,8 @@ class SingleFile:
 
 def _load_files(path, file_types):
     """
-    This method will search a given directory, including all sub-directories, for files of type in file_types.
+    This method will search a given directory, including all sub-directories,
+    for files of type in file_types.
     It will then attempt to determine if the files are in EPICS format.
 
     Args:
@@ -48,7 +49,8 @@ def _load_files(path, file_types):
     for root, dirs, files in os.walk(os.path.normpath(path)):
         dirs[:] = [d for d in dirs if d not in DIRECTORIES_TO_ALWAYS_IGNORE]
 
-        for f in [f for f in files if any(f.endswith(file_type) for file_type in file_types)]:
+        for f in [f for f in files if any(f.endswith(file_type) for
+                                          file_type in file_types)]:
             filename = os.path.abspath(join(root, f))
 
             with open(filename) as _file:
@@ -78,4 +80,5 @@ def parsed_files(path, file_types):
         try:
             yield parse_db(db)
         except (ValueError, LookupError) as e:
-            raise ValueError("Failed to parse DB '{}'. Exception was: {}".format(db.directory, e))
+            raise ValueError("Failed to parse DB '{}'. Exception was: {}"
+                             .format(db.directory, e))


### PR DESCRIPTION
Converting DbUnitChecker to run in Python 3.

Most changes are PEP8 style fixes (lots of lines too long). 

Includes import fixes for python 3 and the use of items() over iteritems().